### PR TITLE
Feature: dynamic env

### DIFF
--- a/lib/capistrano-resque-pool.rb
+++ b/lib/capistrano-resque-pool.rb
@@ -1,0 +1,3 @@
+require "capistrano/resque/pool/version"
+
+load File.expand_path("../capistrano/tasks/capistrano-resque-pool.rake", __FILE__)

--- a/lib/capistrano/tasks/capistrano-resque-pool.rake
+++ b/lib/capistrano/tasks/capistrano-resque-pool.rake
@@ -4,7 +4,7 @@ namespace :resque do
     task :start do
       on roles(workers) do
         within app_path do
-          execute :bundle, :exec, 'resque-pool', '--daemon --environment production'
+          execute :bundle, :exec, 'resque-pool', "--daemon --environment #{fetch(:rails_env)}"
         end
       end
     end 

--- a/lib/capistrano/tasks/capistrano-resque-pool.rake
+++ b/lib/capistrano/tasks/capistrano-resque-pool.rake
@@ -1,10 +1,16 @@
 namespace :resque do 
   namespace :pool do
+    def rails_env
+      fetch(:resque_rails_env) ||
+      fetch(:rails_env) ||       # capistrano-rails doesn't automatically set this (yet),
+      fetch(:stage)              # so we need to fall back to the stage.
+    end
+
     desc 'Start all the workers and queus'
     task :start do
       on roles(workers) do
         within app_path do
-          execute :bundle, :exec, 'resque-pool', "--daemon --environment #{fetch(:rails_env)}"
+          execute :bundle, :exec, 'resque-pool', "--daemon --environment #{rails_env}"
         end
       end
     end 


### PR DESCRIPTION
- Start the pool manager with the current environment ( instead of always production )
- Ability to load module in Cap file using: require "capistrano-resque-pool"
