### PR TITLE
(fixes issue #1) Safe restart if pool-manager is not running

### DIFF
--- a/lib/capistrano-resque-pool.rb
+++ b/lib/capistrano-resque-pool.rb
@@ -1,0 +1,3 @@
+require "capistrano/resque/pool/version"
+
+load File.expand_path("../capistrano/tasks/capistrano-resque-pool.rake", __FILE__)

--- a/lib/capistrano/tasks/capistrano-resque-pool.rake
+++ b/lib/capistrano/tasks/capistrano-resque-pool.rake
@@ -4,7 +4,7 @@ namespace :resque do
     task :start do
       on roles(workers) do
         within app_path do
-          execute :bundle, :exec, 'resque-pool', '--daemon --environment production'
+          execute :bundle, :exec, 'resque-pool', "--daemon --environment #{fetch(:rails_env)}"
         end
       end
     end 

--- a/lib/capistrano/tasks/capistrano-resque-pool.rake
+++ b/lib/capistrano/tasks/capistrano-resque-pool.rake
@@ -1,10 +1,16 @@
 namespace :resque do 
   namespace :pool do
+    def rails_env
+      fetch(:resque_rails_env) ||
+      fetch(:rails_env) ||       # capistrano-rails doesn't automatically set this (yet),
+      fetch(:stage)              # so we need to fall back to the stage.
+    end
+
     desc 'Start all the workers and queus'
     task :start do
       on roles(workers) do
         within app_path do
-          execute :bundle, :exec, 'resque-pool', "--daemon --environment #{fetch(:rails_env)}"
+          execute :bundle, :exec, 'resque-pool', "--daemon --environment #{rails_env}"
         end
       end
     end 

--- a/lib/capistrano/tasks/capistrano-resque-pool.rake
+++ b/lib/capistrano/tasks/capistrano-resque-pool.rake
@@ -32,7 +32,11 @@ namespace :resque do
     desc 'Reload the config file, reload logfiles, restart all workers'
     task :restart do
       on roles(workers) do
-        execute :kill, "-s HUP `cat #{pid_path}`"
+        if test("[ -f #{pid_path} ]")
+          execute :kill, "-s HUP `cat #{pid_path}`"
+        else
+          invoke 'resque:pool:start'
+        end
       end
     end
 


### PR DESCRIPTION
If a restart is issued and the pool-manager is not running ( no pid file exists ) start the pool manager instead of raising an error.
