### PR TITLE
Fix waiting for pool manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Capistrano integration for `resque-pool`.
 
+
 ## Installation
 
 Add this line to your application's Gemfile:
@@ -15,7 +16,12 @@ And then execute:
 Or install it yourself as:
 
     $ gem install capistrano-resque-pool
-    
+
+Finally, require it in your Capfile:
+
+    require 'capistrano-resque-pool'
+
+
 ## Configuration
 
 You can setup the role or list of roles on which your run resque-pool.
@@ -29,6 +35,7 @@ server 'background.example.com', roles: [:worker]
 ```
 
 By default it assumes that resque is located on servers with `app` role.
+
 
 ## Usage
 

--- a/lib/capistrano/tasks/capistrano-resque-pool.rake
+++ b/lib/capistrano/tasks/capistrano-resque-pool.rake
@@ -1,4 +1,4 @@
-namespace :resque do 
+namespace :resque do
   namespace :pool do
     def rails_env
       fetch(:resque_rails_env) ||
@@ -14,12 +14,12 @@ namespace :resque do
           execute :bundle, :exec, 'resque-pool', "--daemon --environment #{rails_env}"
         end
       end
-    end 
+    end
 
     desc 'Gracefully shut down workers and shutdown the manager after all workers are done'
     task :stop do
       on roles(workers) do
-        if pid_file_exists? 
+        if pid_file_exists?
           pid = capture(:cat, pid_path)
           if test "kill -0 #{pid} > /dev/null 2>&1"
             execute :kill, "-s QUIT #{pid}"
@@ -44,12 +44,14 @@ namespace :resque do
 
       # Wait for the manager to stop
       on roles(workers) do
-        info "Waiting for pool manager to stop.. " 
-        if pid_file_exists? 
+        if pid_file_exists?
           pid   = capture(:cat, pid_path)
           tries = 10
+
           while tries >= 0 and test("kill -0 #{pid} > /dev/null 2>&1")
-            tries =- 1
+            info 'Waiting for pool manager to stop..'
+
+            tries -= 1
             sleep 5
           end
         end
@@ -61,7 +63,7 @@ namespace :resque do
     desc 'Reload the config file, reload logfiles, restart all workers'
     task :restart do
       on roles(workers) do
-        if pid_file_exists? 
+        if pid_file_exists?
           execute :kill, "-s HUP `cat #{pid_path}`"
         else
           invoke 'resque:pool:start'


### PR DESCRIPTION
The full_restart task waits for the pool manager to stop. A counter is decremented there, but =- is used instead of -=, which causes the value of '-1' to be assigned to the counter, rather than decrementing the value by 1. So it will never loop.

The diff contains some extra lines because my editor (imo rightfully) gets rid of trailing whitespaces.

If you merge this, could you create a new Release afterwards?

Thanks a lot!
