### PR TITLE
Wait longer for pool manager to exit

### DIFF
--- a/lib/capistrano/tasks/capistrano-resque-pool.rake
+++ b/lib/capistrano/tasks/capistrano-resque-pool.rake
@@ -46,7 +46,7 @@ namespace :resque do
       on roles(workers) do
         if pid_file_exists?
           pid   = capture(:cat, pid_path)
-          tries = 10
+          tries = 20
 
           while tries >= 0 and test("kill -0 #{pid} > /dev/null 2>&1")
             info 'Waiting for pool manager to stop..'


### PR DESCRIPTION
I've noticed that on rare occasions, the pool manager can take a while to exit. If this happens, no new resque-pool is started, and the old one still exits after a while. Leaving the deployment without any resque-pool at all.

This is a small PR to wait longer for the manager to exit.
