### PR TITLE
Avoid race condition reading pid_path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ _yardoc
 coverage
 doc/
 lib/bundler/man
+nix
 pkg
 rdoc
 spec/reports
@@ -20,3 +21,4 @@ tmp
 *.o
 *.a
 mkmf.log
+shell.nix

--- a/lib/capistrano/resque/pool/version.rb
+++ b/lib/capistrano/resque/pool/version.rb
@@ -1,7 +1,7 @@
 module Capistrano
   module Resque
     module Pool
-      VERSION = '0.2.0'
+      VERSION = '0.2.1'
     end
   end
 end

--- a/lib/capistrano/tasks/capistrano-resque-pool.rake
+++ b/lib/capistrano/tasks/capistrano-resque-pool.rake
@@ -28,8 +28,8 @@ namespace :resque do
     desc 'Gracefully shut down workers and shutdown the manager after all workers are done'
     task :stop do
       on roles(workers) do
-        if pid_file_exists?
-          pid = capture(:cat, pid_path)
+        pid = read_pid_file
+        if !pid.empty?
           if test "kill -0 #{pid} > /dev/null 2>&1"
             execute :kill, "-s QUIT #{pid}"
           else
@@ -53,8 +53,8 @@ namespace :resque do
 
       # Wait for the manager to stop
       on roles(workers) do
-        if pid_file_exists?
-          pid   = capture(:cat, pid_path)
+        pid = read_pid_file
+        if !pid.empty?
           tries = 20
 
           while tries >= 0 and test("kill -0 #{pid} > /dev/null 2>&1")
@@ -94,6 +94,10 @@ namespace :resque do
 
     def workers
       fetch(:resque_server_roles) || :app
+    end
+
+    def read_pid_file
+      capture("cat #{pid_path} 2> /dev/null || true")
     end
   end
 end


### PR DESCRIPTION
# Problem

There is a race condition in `full_restart` tasks between lines 56 and 57, since first there is an IF statement checking if the PID file is present, and then `cat` the content of it, however, by the time the `cat` command is invoked, the file might not exist, this happened to me in a deployment process, here is the stack trace:

https://github.com/datarockets/capistrano-resque-pool/blob/40aa41454120a8a7127a98cc3069cb320bde2156/lib/capistrano/tasks/capistrano-resque-pool.rake#L55-L65

```
#<Thread:0x00007ff5b810c9c0@vendor/bundle/ruby/2.6.0/gems/sshkit-1.21.1/lib/sshkit/runners/parallel.rb:10 run> terminated with exception (report_on_exception is true):              
Traceback (most recent call last):                                                                                                                                                                                                            
        9: from vendor/bundle/ruby/2.6.0/gems/sshkit-1.21.1/lib/sshkit/runners/parallel.rb:12:in `block (2 levels) in execute'                                                       
        8: from vendor/bundle/ruby/2.6.0/gems/sshkit-1.21.1/lib/sshkit/backends/abstract.rb:31:in `run'                                                                              
        7: from vendor/bundle/ruby/2.6.0/gems/sshkit-1.21.1/lib/sshkit/backends/abstract.rb:31:in `instance_exec'                                                                    
        6: from vendor/bundle/ruby/2.6.0/gems/capistrano-resque-pool-0.2.0/lib/capistrano/tasks/capistrano-resque-pool.rake:59:in `block (4 levels) in <top (required)>'             
        5: from vendor/bundle/ruby/2.6.0/gems/sshkit-1.21.1/lib/sshkit/backends/abstract.rb:66:in `capture'                                                                          
        4: from vendor/bundle/ruby/2.6.0/gems/sshkit-1.21.1/lib/sshkit/backends/abstract.rb:148:in `create_command_and_execute'                                                      
        3: from vendor/bundle/ruby/2.6.0/gems/sshkit-1.21.1/lib/sshkit/backends/abstract.rb:148:in `tap'                                                                             
        2: from vendor/bundle/ruby/2.6.0/gems/sshkit-1.21.1/lib/sshkit/backends/abstract.rb:148:in `block in create_command_and_execute'                                             
        1: from vendor/bundle/ruby/2.6.0/gems/sshkit-1.21.1/lib/sshkit/backends/netssh.rb:170:in `execute_command'                                                                   
vendor/bundle/ruby/2.6.0/gems/sshkit-1.21.1/lib/sshkit/command.rb:97:in `exit_status=': cat exit status: 1 (SSHKit::Command::Failed)                                                 
cat stdout: Nothing written
cat stderr: cat: current/tmp/pids/resque-pool.pid: No such file or directory
```
After adding some `puts` in the code (old fashioned debugging) I got the following output:

![image](https://user-images.githubusercontent.com/2049686/104357236-e7977a80-54da-11eb-9f5b-cb128447b0be.png)

```
>>> 1 true                                                                                                                                                                                                                                    
>>> 2 false                                                                                                                                                                                                                                   
```

# Proposed Solution

Attempt to read the PID file from the server directly and ignore the error if the file is not present, then instead of checking if the file is present, validate the output produced by `cat`.